### PR TITLE
Fix silent bookmark-save failure on prod

### DIFF
--- a/src/components/BookmarksModal.tsx
+++ b/src/components/BookmarksModal.tsx
@@ -2,7 +2,15 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { Bookmark, getBookmarks, deleteBookmark, updateBookmark, formatDateRange } from '@/lib/bookmarks';
+import {
+  Bookmark,
+  BookmarkToast,
+  getBookmarks,
+  deleteBookmark,
+  updateBookmark,
+  formatDateRange,
+  messageForBookmarkError,
+} from '@/lib/bookmarks';
 import BookmarkCard from './BookmarkCard';
 import SaveBookmarkModal from './SaveBookmarkModal';
 
@@ -124,11 +132,13 @@ interface BookmarksModalProps {
   isOpen: boolean;
   onClose: () => void;
   onViewBookmark: (bookmark: Bookmark) => void;
+  onBookmarkToast?: (toast: BookmarkToast) => void;
 }
 
-const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onViewBookmark }) => {
+const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onViewBookmark, onBookmarkToast }) => {
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
   const [editingBookmark, setEditingBookmark] = useState<Bookmark | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
   const [isScrolled, setIsScrolled] = useState(false);
 
   // Load bookmarks when modal opens
@@ -162,20 +172,40 @@ const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onView
   };
 
   const handleEdit = (bookmark: Bookmark) => {
+    setEditError(null);
     setEditingBookmark(bookmark);
   };
 
   const handleDelete = (bookmark: Bookmark) => {
-    deleteBookmark(bookmark.id);
+    const result = deleteBookmark(bookmark.id);
+    if (!result.ok && result.kind !== 'not_found') {
+      const message = messageForBookmarkError(result.kind);
+      onBookmarkToast?.({ kind: 'error', message });
+      return;
+    }
     setBookmarks(getBookmarks());
   };
 
-  const handleSaveEdit = (name: string, description: string) => {
-    if (editingBookmark) {
-      updateBookmark(editingBookmark.id, { name, description });
-      setBookmarks(getBookmarks());
-      setEditingBookmark(null);
+  const handleSaveEdit = (name: string, description: string): boolean => {
+    if (!editingBookmark) return true;
+    const result = updateBookmark(editingBookmark.id, { name, description });
+    if (!result.ok) {
+      // If the bookmark was somehow deleted underneath us, close the edit modal
+      // rather than leaving the user stuck in an un-saveable state.
+      if (result.kind === 'not_found') {
+        setEditingBookmark(null);
+        setBookmarks(getBookmarks());
+        return true;
+      }
+      const message = messageForBookmarkError(result.kind);
+      setEditError(message);
+      onBookmarkToast?.({ kind: 'error', message });
+      return false;
     }
+    setBookmarks(getBookmarks());
+    setEditingBookmark(null);
+    setEditError(null);
+    return true;
   };
 
   if (!isOpen) return null;
@@ -317,12 +347,13 @@ const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onView
           return (
             <SaveBookmarkModal
               isOpen={true}
-              onClose={() => setEditingBookmark(null)}
+              onClose={() => { setEditingBookmark(null); setEditError(null); }}
               onSave={handleSaveEdit}
               initialName={editingBookmark.name}
               initialDescription={editingBookmark.description}
               mode="edit"
               bookmarkImage={editingBookmark.image}
+              errorMessage={editError}
               contextTitle={contextTitle}
               contextType={contextType}
               contextSubtitle={contextSubtitle}

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -26,7 +26,7 @@ import type { InsightCard as InsightCardType, WalkthroughFilterState } from '@/t
 import { StoryModePanel } from '@/components/insights/StoryModePanel';
 import type { FilterState } from '@/lib/utils/filterBuilder';
 import { prefetchWalkthroughSteps, hydrateCacheFromLocalStorage } from '@/lib/utils/prefetch';
-import { Bookmark, BookmarkState, saveBookmark } from '@/lib/bookmarks';
+import { Bookmark, BookmarkState, BookmarkToast, messageForBookmarkError, saveBookmark } from '@/lib/bookmarks';
 import { calculateBounds as calculateBoundsUtil } from '@/lib/mapUtils';
 import { MapThumbnailCapture } from '@/components/insights/MapThumbnailCapture';
 import type { MapThumbnailCaptureHandle } from '@/components/insights/MapThumbnailCapture';
@@ -516,9 +516,17 @@ export default function MapCanvas() {
 
   // Bookmark capture state
   const [isSaveBookmarkModalOpen, setIsSaveBookmarkModalOpen] = useState<boolean>(false);
-  const [showBookmarkSavedToast, setShowBookmarkSavedToast] = useState<boolean>(false);
+  const [bookmarkToast, setBookmarkToast] = useState<BookmarkToast | null>(null);
+  const [bookmarkSaveError, setBookmarkSaveError] = useState<string | null>(null);
   const [pendingBookmarkImage, setPendingBookmarkImage] = useState<string | null>(null);
   const [isCapturingBookmark, setIsCapturingBookmark] = useState<boolean>(false);
+
+  const showBookmarkToast = (toast: BookmarkToast) => {
+    setBookmarkToast(toast);
+    setTimeout(() => {
+      setBookmarkToast((current) => (current === toast ? null : current));
+    }, toast.kind === 'saved' ? 3000 : 5000);
+  };
 
   // Comparison mode state
   const [comparisonMode, setComparisonMode] = useState<boolean>(false);
@@ -5564,7 +5572,7 @@ export default function MapCanvas() {
           homeChatEnabled={homeChatEnabled}
           onHomeChatEnabledChange={setHomeChatEnabled}
           onOpenBookmarks={() => setIsBookmarksModalOpen(true)}
-          showBookmarkSavedToast={showBookmarkSavedToast}
+          bookmarkToast={bookmarkToast}
         />
       </div>
 
@@ -8652,6 +8660,7 @@ export default function MapCanvas() {
       <button
           onClick={async () => {
             // Show scrim and modal simultaneously - no delay
+            setBookmarkSaveError(null);
             setIsCapturingBookmark(true);
             setIsSaveBookmarkModalOpen(true);
 
@@ -8739,8 +8748,10 @@ export default function MapCanvas() {
               const cropY = 0;
               const cropWidth = mapCanvas.width;
               const cropHeight = mapCanvas.height;
-              // Output at same aspect ratio, scaled to reasonable size
-              const maxDimension = 1920;
+              // Output at same aspect ratio. Capped small because bookmark images live in
+              // localStorage (~5 MB per-origin quota) and a single 1920px JPEG can exceed
+              // 1 MB, so a handful of bookmarks would push the user over the limit.
+              const maxDimension = 800;
               const scale = Math.min(maxDimension / cropWidth, maxDimension / cropHeight, 1);
               const outputWidth = Math.round(cropWidth * scale);
               const outputHeight = Math.round(cropHeight * scale);
@@ -8767,7 +8778,7 @@ export default function MapCanvas() {
                 );
               }
 
-              const dataUrl = compositeCanvas.toDataURL('image/jpeg', 0.8);
+              const dataUrl = compositeCanvas.toDataURL('image/jpeg', 0.7);
               setPendingBookmarkImage(dataUrl);
 
               // Restore original view state
@@ -12761,8 +12772,10 @@ export default function MapCanvas() {
             setIsSaveBookmarkModalOpen(false);
             setIsCapturingBookmark(false);
             setPendingBookmarkImage(null);
+            setBookmarkSaveError(null);
           },
           bookmarkImage: pendingBookmarkImage,
+          errorMessage: bookmarkSaveError,
           contextTitle: selectedRouteId
             ? (() => {
                 const routeName = routesList.find(r => r.id === selectedRouteId)?.name || `Route ${selectedRouteId}`;
@@ -12994,24 +13007,31 @@ export default function MapCanvas() {
             },
           };
 
-          saveBookmark({
+          setBookmarkSaveError(null);
+          const result = saveBookmark({
             name,
             description,
             state: bookmarkState,
             ...(pendingBookmarkImage && { image: pendingBookmarkImage }),
           });
 
+          if (!result.ok) {
+            const message = messageForBookmarkError(result.kind);
+            setBookmarkSaveError(message);
+            showBookmarkToast({ kind: 'error', message });
+            return false;
+          }
+
           // Clear the pending image and hide scrim
           setPendingBookmarkImage(null);
           setIsCapturingBookmark(false);
 
-            // Show toast notification
-            setShowBookmarkSavedToast(true);
-            setTimeout(() => setShowBookmarkSavedToast(false), 3000);
+          showBookmarkToast({ kind: 'saved' });
 
-            // Refresh bookmarks modal if it's using window.refreshBookmarks
-            const refreshFn = (window as unknown as { refreshBookmarks?: () => void }).refreshBookmarks;
-            if (refreshFn) refreshFn();
+          // Refresh bookmarks modal if it's using window.refreshBookmarks
+          const refreshFn = (window as unknown as { refreshBookmarks?: () => void }).refreshBookmarks;
+          if (refreshFn) refreshFn();
+          return true;
           },
         };
 
@@ -13022,6 +13042,7 @@ export default function MapCanvas() {
       <BookmarksModal
         isOpen={isBookmarksModalOpen}
         onClose={() => setIsBookmarksModalOpen(false)}
+        onBookmarkToast={showBookmarkToast}
         onViewBookmark={(bookmark) => {
           // Restore state from bookmark
           const state = bookmark.state;

--- a/src/components/NavRail.tsx
+++ b/src/components/NavRail.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import type { BookmarkToast } from '@/lib/bookmarks';
 
 interface NavRailProps {
   activeTab: 'home' | 'system' | 'routes' | 'stops' | 'components';
@@ -18,7 +19,7 @@ interface NavRailProps {
   homeChatEnabled: boolean;
   onHomeChatEnabledChange: (value: boolean) => void;
   onOpenBookmarks: () => void;
-  showBookmarkSavedToast?: boolean;
+  bookmarkToast?: BookmarkToast | null;
 }
 
 // Inline SVG components for nav icons
@@ -140,8 +141,10 @@ const NavRail: React.FC<NavRailProps> = ({
   homeChatEnabled,
   onHomeChatEnabledChange,
   onOpenBookmarks,
-  showBookmarkSavedToast = false
+  bookmarkToast = null
 }) => {
+  const isSavedToast = bookmarkToast?.kind === 'saved';
+  const isErrorToast = bookmarkToast?.kind === 'error';
   const [isHoveringFilters, setIsHoveringFilters] = useState(false);
   const [panelStateOnHover, setPanelStateOnHover] = useState<boolean | null>(null);
   const [hasClicked, setHasClicked] = useState(false);
@@ -324,7 +327,7 @@ const NavRail: React.FC<NavRailProps> = ({
           style={{
             marginBottom: '0',
             backgroundColor: '#D9D4EA',
-            border: showBookmarkSavedToast ? '2px solid #2D7A4F' : 'none',
+            border: isSavedToast ? '2px solid #2D7A4F' : 'none',
             transition: 'border 0.2s ease, background-color 0.2s ease',
           }}
           onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = '#CEC7E3'; }}
@@ -338,26 +341,29 @@ const NavRail: React.FC<NavRailProps> = ({
         </button>
       </div>
 
-      {/* Bookmark Saved Toast - rendered via portal */}
-      {showBookmarkSavedToast && profileButtonRef.current && createPortal(
+      {/* Bookmark Toast - rendered via portal. Green for success, red for errors. */}
+      {bookmarkToast && profileButtonRef.current && createPortal(
         <div
+          role={isErrorToast ? 'alert' : 'status'}
           style={{
             position: 'fixed',
             top: profileButtonRef.current.getBoundingClientRect().top + profileButtonRef.current.getBoundingClientRect().height / 2,
             left: profileButtonRef.current.getBoundingClientRect().right + 8,
             transform: 'translateY(-50%)',
-            backgroundColor: '#2D7A4F',
+            backgroundColor: isErrorToast ? '#B3261E' : '#2D7A4F',
             color: 'white',
             padding: '8px 12px',
             borderRadius: '8px',
             fontSize: '13px',
             fontWeight: 500,
-            whiteSpace: 'nowrap',
+            whiteSpace: isErrorToast ? 'normal' : 'nowrap',
+            maxWidth: isErrorToast ? '320px' : undefined,
+            lineHeight: '18px',
             boxShadow: 'var(--shadow-md)',
             zIndex: 10000,
           }}
         >
-          Bookmark Saved
+          {isSavedToast ? 'Bookmark Saved' : bookmarkToast.message}
         </div>,
         document.body
       )}

--- a/src/components/SaveBookmarkModal.tsx
+++ b/src/components/SaveBookmarkModal.tsx
@@ -37,7 +37,9 @@ const getViewIcon = (contextType: string | undefined) => {
 interface SaveBookmarkModalFullScreenProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (name: string, description: string) => void;
+  // Returning false (or a Promise resolving to false) keeps the modal open so the user
+  // can see an error message and retry. Returning void is treated as success.
+  onSave: (name: string, description: string) => boolean | void | Promise<boolean | void>;
   initialName?: string;
   initialDescription?: string;
   mode?: 'create' | 'edit';
@@ -46,6 +48,7 @@ interface SaveBookmarkModalFullScreenProps {
   contextSubtitle?: string;
   contextFilters?: string;
   bookmarkImage?: string | null;
+  errorMessage?: string | null;
   // Comparison mode date ranges
   comparisonMode?: boolean;
   primaryDateLabel?: string;
@@ -64,6 +67,7 @@ const SaveBookmarkModalFullScreen: React.FC<SaveBookmarkModalFullScreenProps> = 
   contextSubtitle,
   contextFilters,
   bookmarkImage,
+  errorMessage,
   comparisonMode,
   primaryDateLabel,
   comparisonDateLabel,
@@ -71,6 +75,7 @@ const SaveBookmarkModalFullScreen: React.FC<SaveBookmarkModalFullScreenProps> = 
   const [name, setName] = useState(initialName);
   const [description, setDescription] = useState(initialDescription);
   const [isDescriptionFocused, setIsDescriptionFocused] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
 
@@ -78,16 +83,21 @@ const SaveBookmarkModalFullScreen: React.FC<SaveBookmarkModalFullScreenProps> = 
     if (isOpen) {
       setName(initialName);
       setDescription(initialDescription);
+      setIsSubmitting(false);
       // Focus the name input when modal opens
       setTimeout(() => nameInputRef.current?.focus(), 100);
     }
   }, [isOpen, initialName, initialDescription]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (name.trim()) {
-      onSave(name.trim(), description.trim());
-      onClose();
+    if (!name.trim() || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const result = await onSave(name.trim(), description.trim());
+      if (result !== false) onClose();
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -270,6 +280,24 @@ const SaveBookmarkModalFullScreen: React.FC<SaveBookmarkModalFullScreenProps> = 
           {/* Spacer to push buttons to bottom */}
           <div style={{ flex: 1 }} />
 
+          {errorMessage && (
+            <div
+              role="alert"
+              style={{
+                marginBottom: '12px',
+                padding: '10px 12px',
+                borderRadius: '12px',
+                backgroundColor: 'rgba(179, 38, 30, 0.1)',
+                border: '0.5px solid rgba(179, 38, 30, 0.4)',
+                color: '#B3261E',
+                fontSize: '13px',
+                lineHeight: '18px',
+              }}
+            >
+              {errorMessage}
+            </div>
+          )}
+
           {/* Buttons at bottom of panel */}
           <div
             style={{
@@ -291,7 +319,7 @@ const SaveBookmarkModalFullScreen: React.FC<SaveBookmarkModalFullScreenProps> = 
               type="button"
               variant="primary"
               size="medium"
-              disabled={!name.trim()}
+              disabled={!name.trim() || isSubmitting}
               onClick={handleSubmit}
               style={{ minWidth: '100px', whiteSpace: 'nowrap' }}
             >

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -85,6 +85,64 @@ export interface Bookmark {
 // Keep old key for backwards compatibility - will read from old storage
 const BOOKMARKS_STORAGE_KEY = 'transit-proto-snapshots';
 
+export type BookmarkErrorKind = 'quota' | 'unavailable' | 'unknown';
+
+export type SaveBookmarkResult =
+  | { ok: true; bookmark: Bookmark }
+  | { ok: false; kind: BookmarkErrorKind; error: unknown };
+
+export type UpdateBookmarkResult =
+  | { ok: true; bookmark: Bookmark }
+  | { ok: false; kind: BookmarkErrorKind | 'not_found'; error?: unknown };
+
+export type DeleteBookmarkResult =
+  | { ok: true }
+  | { ok: false; kind: BookmarkErrorKind | 'not_found'; error?: unknown };
+
+export type BookmarkToast =
+  | { kind: 'saved' }
+  | { kind: 'error'; message: string };
+
+// Classifies any localStorage write failure into a discriminated kind so the UI can
+// show an appropriate message (quota exceeded is recoverable by deleting bookmarks;
+// unavailable usually means private browsing).
+function isQuotaError(e: unknown): boolean {
+  if (!(e instanceof DOMException)) return false;
+  // Standard, Firefox legacy (1014 / NS_ERROR_DOM_QUOTA_REACHED), and code 22.
+  return (
+    e.name === 'QuotaExceededError' ||
+    e.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    e.code === 22 ||
+    e.code === 1014
+  );
+}
+
+function writeAll(bookmarks: Bookmark[]): { ok: true } | { ok: false; kind: BookmarkErrorKind; error: unknown } {
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+    return { ok: false, kind: 'unavailable', error: new Error('localStorage is not available') };
+  }
+  try {
+    localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(bookmarks));
+    return { ok: true };
+  } catch (e) {
+    const kind: BookmarkErrorKind = isQuotaError(e) ? 'quota' : 'unknown';
+    console.error('Failed to write bookmarks to localStorage:', e);
+    return { ok: false, kind, error: e };
+  }
+}
+
+export function messageForBookmarkError(kind: BookmarkErrorKind): string {
+  switch (kind) {
+    case 'quota':
+      return "Can't save — browser storage is full. Delete a few bookmarks and try again.";
+    case 'unavailable':
+      return "Can't save — browser storage is unavailable (private mode?).";
+    case 'unknown':
+    default:
+      return 'Couldn\u2019t save bookmark. Please try again.';
+  }
+}
+
 // Get all bookmarks from localStorage
 export function getBookmarks(): Bookmark[] {
   if (typeof window === 'undefined') return [];
@@ -100,7 +158,9 @@ export function getBookmarks(): Bookmark[] {
 }
 
 // Save a new bookmark
-export function saveBookmark(bookmark: Omit<Bookmark, 'id' | 'createdAt' | 'updatedAt'>): Bookmark {
+export function saveBookmark(
+  bookmark: Omit<Bookmark, 'id' | 'createdAt' | 'updatedAt'>,
+): SaveBookmarkResult {
   const bookmarks = getBookmarks();
   const now = new Date().toISOString();
 
@@ -111,38 +171,44 @@ export function saveBookmark(bookmark: Omit<Bookmark, 'id' | 'createdAt' | 'upda
     updatedAt: now,
   };
 
-  bookmarks.push(newBookmark);
-  localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(bookmarks));
-
-  return newBookmark;
+  const result = writeAll([...bookmarks, newBookmark]);
+  if (!result.ok) return result;
+  return { ok: true, bookmark: newBookmark };
 }
 
 // Update an existing bookmark
-export function updateBookmark(id: string, updates: Partial<Pick<Bookmark, 'name' | 'description'>>): Bookmark | null {
+export function updateBookmark(
+  id: string,
+  updates: Partial<Pick<Bookmark, 'name' | 'description'>>,
+): UpdateBookmarkResult {
   const bookmarks = getBookmarks();
   const index = bookmarks.findIndex(b => b.id === id);
 
-  if (index === -1) return null;
+  if (index === -1) return { ok: false, kind: 'not_found' };
 
-  bookmarks[index] = {
+  const updated: Bookmark = {
     ...bookmarks[index],
     ...updates,
     updatedAt: new Date().toISOString(),
   };
+  const next = bookmarks.slice();
+  next[index] = updated;
 
-  localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(bookmarks));
-  return bookmarks[index];
+  const result = writeAll(next);
+  if (!result.ok) return result;
+  return { ok: true, bookmark: updated };
 }
 
 // Delete a bookmark
-export function deleteBookmark(id: string): boolean {
+export function deleteBookmark(id: string): DeleteBookmarkResult {
   const bookmarks = getBookmarks();
   const filtered = bookmarks.filter(b => b.id !== id);
 
-  if (filtered.length === bookmarks.length) return false;
+  if (filtered.length === bookmarks.length) return { ok: false, kind: 'not_found' };
 
-  localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(filtered));
-  return true;
+  const result = writeAll(filtered);
+  if (!result.ok) return result;
+  return { ok: true };
 }
 
 // Get a single bookmark by ID


### PR DESCRIPTION
## Summary

- Fixes a prod bug where clicking "Save" on a new bookmark did nothing — the modal didn't close, no bookmark was saved, no error was shown. Root cause: `localStorage.setItem` was throwing `QuotaExceededError` (bookmark screenshots were base64-encoded at 1920px/quality 0.8, ~500 KB–1.5 MB each, and ~4 of them exhausted the ~5 MB origin quota), and the exception bubbled up through an unguarded `saveBookmark` call into `handleSubmit`, skipping the `onClose()` that follows.
- Shrinks the screenshot to 800px / JPEG quality 0.7 — typical payload now ~80 KB, so ~50× more bookmarks fit under the quota. Verified locally: new image is 33 KB.
- Makes `saveBookmark` / `updateBookmark` / `deleteBookmark` return a discriminated result instead of throwing. Errors are classified as `'quota' | 'unavailable' | 'unknown'` and surfaced through a red inline banner in the modal plus a red toast.
- Same error handling applied to the edit and delete paths in `BookmarksModal`, which had the same silent-failure bug.

## Files changed

- `src/lib/bookmarks.ts` — result types, `isQuotaError` helper, `writeAll` wrapper, `messageForBookmarkError` helper.
- `src/components/MapCanvas.tsx` — screenshot compression, new `bookmarkToast` + `bookmarkSaveError` state, save handler checks result.
- `src/components/SaveBookmarkModal.tsx` — `onSave` can return `false` to keep modal open, inline `errorMessage` banner, `isSubmitting` disables the Save button.
- `src/components/NavRail.tsx` — toast supports `saved` (green, 3s) and `error` (red, 5s) variants via a shared `BookmarkToast` type.
- `src/components/BookmarksModal.tsx` — edit and delete flows check results and forward errors via `onBookmarkToast`.

## Test plan

- [x] Happy path: create a bookmark, verify modal closes, green "Bookmark Saved" toast, bookmark appears in list.
- [x] Verify image size in `localStorage` is ~80 KB, not ~500 KB+.
- [x] Quota path: patch `Storage.prototype.setItem` to throw `QuotaExceededError`, attempt a save — modal stays open, inline red error "Can't save — browser storage is full…", red toast visible.
- [x] Recovery: un-patch, save again — success.
- [ ] Edit path: with `setItem` patched, edit a bookmark's name — error surfaces, bookmark unchanged.
- [ ] Delete path: with `setItem` patched, delete a bookmark — error toast, bookmark still present.
- [ ] Deploy to prod and confirm with affected user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
