### PR TITLE
Story mode polish: pattern bug, perf, UX fixes

### DIFF
--- a/src/components/BookmarksModal.tsx
+++ b/src/components/BookmarksModal.tsx
@@ -138,7 +138,6 @@ interface BookmarksModalProps {
 const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onViewBookmark, onBookmarkToast }) => {
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
   const [editingBookmark, setEditingBookmark] = useState<Bookmark | null>(null);
-  const [editError, setEditError] = useState<string | null>(null);
   const [isScrolled, setIsScrolled] = useState(false);
 
   // Load bookmarks when modal opens
@@ -172,7 +171,6 @@ const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onView
   };
 
   const handleEdit = (bookmark: Bookmark) => {
-    setEditError(null);
     setEditingBookmark(bookmark);
   };
 
@@ -197,14 +195,11 @@ const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onView
         setBookmarks(getBookmarks());
         return true;
       }
-      const message = messageForBookmarkError(result.kind);
-      setEditError(message);
-      onBookmarkToast?.({ kind: 'error', message });
+      onBookmarkToast?.({ kind: 'error', message: messageForBookmarkError(result.kind) });
       return false;
     }
     setBookmarks(getBookmarks());
     setEditingBookmark(null);
-    setEditError(null);
     return true;
   };
 
@@ -347,13 +342,12 @@ const BookmarksModal: React.FC<BookmarksModalProps> = ({ isOpen, onClose, onView
           return (
             <SaveBookmarkModal
               isOpen={true}
-              onClose={() => { setEditingBookmark(null); setEditError(null); }}
+              onClose={() => setEditingBookmark(null)}
               onSave={handleSaveEdit}
               initialName={editingBookmark.name}
               initialDescription={editingBookmark.description}
               mode="edit"
               bookmarkImage={editingBookmark.image}
-              errorMessage={editError}
               contextTitle={contextTitle}
               contextType={contextType}
               contextSubtitle={contextSubtitle}

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -517,7 +517,6 @@ export default function MapCanvas() {
   // Bookmark capture state
   const [isSaveBookmarkModalOpen, setIsSaveBookmarkModalOpen] = useState<boolean>(false);
   const [bookmarkToast, setBookmarkToast] = useState<BookmarkToast | null>(null);
-  const [bookmarkSaveError, setBookmarkSaveError] = useState<string | null>(null);
   const [pendingBookmarkImage, setPendingBookmarkImage] = useState<string | null>(null);
   const [isCapturingBookmark, setIsCapturingBookmark] = useState<boolean>(false);
 
@@ -2628,8 +2627,14 @@ export default function MapCanvas() {
   const prefetchWalkthroughData = useCallback((steps: import('@/types/insights').WalkthroughStep[]) => {
     // Grid endpoint gates segment coloring — include it on the click path so
     // pages 2+ also warm up while the user reads page 1.
-    prefetchWalkthroughSteps(steps, routesList, { includeGrid: true, includeComparison: true });
-  }, [routesList]);
+    // routePatterns is required so prefetched URLs for pattern-scoped steps
+    // include `&direction=` and match the live query's cache key.
+    prefetchWalkthroughSteps(steps, routesList, {
+      includeGrid: true,
+      includeComparison: true,
+      routePatterns,
+    });
+  }, [routesList, routePatterns]);
 
   const handleAnalyzeInsight = useCallback((insight: InsightCardType) => {
     // If insight has walkthrough steps, enter story mode
@@ -4589,10 +4594,13 @@ export default function MapCanvas() {
     })();
   }, [fitToBounds]);
 
-  // Reset pattern filter, trip filters, and sort when route changes
-  // Skip this when restoring a bookmark (filters are restored separately)
+  // Reset pattern filter, trip filters, and sort when route changes.
+  // Skipped when restoring a bookmark (filters are restored separately) and
+  // when in story mode: walkthrough steps pick their own pattern/filters, and
+  // the route id can change during a same-route step (e.g. short name "44" →
+  // full id once routesList loads) which would otherwise wipe the pattern.
   useEffect(() => {
-    if (isRestoringBookmarkRef.current) {
+    if (isRestoringBookmarkRef.current || isStoryMode) {
       return;
     }
     setSelectedPattern(null);
@@ -4604,7 +4612,20 @@ export default function MapCanvas() {
     // Reset sort to default (time ascending)
     setTripSortBy('time');
     setTripSortOrder('asc');
-  }, [selectedRouteId]);
+  }, [selectedRouteId, isStoryMode]);
+
+  // Re-resolve a walkthrough's short-name route id once routesList arrives.
+  // applyWalkthroughStep captures routesList at call time — if the user clicks
+  // a story card before the list finishes loading, selectedRouteId stays as the
+  // short name ('44') which matches nothing in shapes (keyed by full ids like
+  // '100224') and the map renders empty until something else nudges it.
+  useEffect(() => {
+    if (!isStoryMode || !selectedRouteId || routesList.length === 0) return;
+    const match = routesList.find(r => r.shortName === selectedRouteId || r.id === selectedRouteId);
+    if (match && match.id !== selectedRouteId) {
+      setSelectedRouteId(match.id);
+    }
+  }, [routesList, isStoryMode, selectedRouteId]);
 
   // Reset trips scroll position when route or pattern changes
   useEffect(() => {
@@ -8003,13 +8024,16 @@ export default function MapCanvas() {
           style={{
             position: 'fixed',
             top: 0,
-            left: isFiltersPanelOpen ? '716px' : '460px',
+            // Story panel right edge = 72 + 432 = 504. Without the adjustment the scrim starts
+            // inside the panel area and paints a visible tinted band over the left of the map.
+            left: isStoryPanelVisible ? '504px' : (isFiltersPanelOpen ? '716px' : '460px'),
             right: 0,
             bottom: 0,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            backgroundColor: 'rgba(255, 255, 255, 0.3)',
+            // No tint in story mode — the panel itself already frames the loading context.
+            backgroundColor: isStoryPanelVisible ? 'transparent' : 'rgba(255, 255, 255, 0.3)',
             zIndex: 500,
             pointerEvents: 'none',
             transition: 'left 300ms ease-in-out',
@@ -8660,7 +8684,6 @@ export default function MapCanvas() {
       <button
           onClick={async () => {
             // Show scrim and modal simultaneously - no delay
-            setBookmarkSaveError(null);
             setIsCapturingBookmark(true);
             setIsSaveBookmarkModalOpen(true);
 
@@ -8748,10 +8771,10 @@ export default function MapCanvas() {
               const cropY = 0;
               const cropWidth = mapCanvas.width;
               const cropHeight = mapCanvas.height;
-              // Output at same aspect ratio. Capped small because bookmark images live in
-              // localStorage (~5 MB per-origin quota) and a single 1920px JPEG can exceed
-              // 1 MB, so a handful of bookmarks would push the user over the limit.
-              const maxDimension = 800;
+              // Output at same aspect ratio. Capped because bookmark images live in
+              // localStorage (~5 MB per-origin quota); 1400px JPEG @ quality 0.8 is
+              // ~150 KB, so ~25 bookmarks fit alongside the prefetch cache budget.
+              const maxDimension = 1400;
               const scale = Math.min(maxDimension / cropWidth, maxDimension / cropHeight, 1);
               const outputWidth = Math.round(cropWidth * scale);
               const outputHeight = Math.round(cropHeight * scale);
@@ -8778,7 +8801,7 @@ export default function MapCanvas() {
                 );
               }
 
-              const dataUrl = compositeCanvas.toDataURL('image/jpeg', 0.7);
+              const dataUrl = compositeCanvas.toDataURL('image/jpeg', 0.8);
               setPendingBookmarkImage(dataUrl);
 
               // Restore original view state
@@ -12772,10 +12795,8 @@ export default function MapCanvas() {
             setIsSaveBookmarkModalOpen(false);
             setIsCapturingBookmark(false);
             setPendingBookmarkImage(null);
-            setBookmarkSaveError(null);
           },
           bookmarkImage: pendingBookmarkImage,
-          errorMessage: bookmarkSaveError,
           contextTitle: selectedRouteId
             ? (() => {
                 const routeName = routesList.find(r => r.id === selectedRouteId)?.name || `Route ${selectedRouteId}`;
@@ -13007,7 +13028,6 @@ export default function MapCanvas() {
             },
           };
 
-          setBookmarkSaveError(null);
           const result = saveBookmark({
             name,
             description,
@@ -13016,9 +13036,7 @@ export default function MapCanvas() {
           });
 
           if (!result.ok) {
-            const message = messageForBookmarkError(result.kind);
-            setBookmarkSaveError(message);
-            showBookmarkToast({ kind: 'error', message });
+            showBookmarkToast({ kind: 'error', message: messageForBookmarkError(result.kind) });
             return false;
           }
 

--- a/src/components/SaveBookmarkModal.tsx
+++ b/src/components/SaveBookmarkModal.tsx
@@ -48,7 +48,6 @@ interface SaveBookmarkModalFullScreenProps {
   contextSubtitle?: string;
   contextFilters?: string;
   bookmarkImage?: string | null;
-  errorMessage?: string | null;
   // Comparison mode date ranges
   comparisonMode?: boolean;
   primaryDateLabel?: string;
@@ -67,7 +66,6 @@ const SaveBookmarkModalFullScreen: React.FC<SaveBookmarkModalFullScreenProps> = 
   contextSubtitle,
   contextFilters,
   bookmarkImage,
-  errorMessage,
   comparisonMode,
   primaryDateLabel,
   comparisonDateLabel,
@@ -279,24 +277,6 @@ const SaveBookmarkModalFullScreen: React.FC<SaveBookmarkModalFullScreenProps> = 
 
           {/* Spacer to push buttons to bottom */}
           <div style={{ flex: 1 }} />
-
-          {errorMessage && (
-            <div
-              role="alert"
-              style={{
-                marginBottom: '12px',
-                padding: '10px 12px',
-                borderRadius: '12px',
-                backgroundColor: 'rgba(179, 38, 30, 0.1)',
-                border: '0.5px solid rgba(179, 38, 30, 0.4)',
-                color: '#B3261E',
-                fontSize: '13px',
-                lineHeight: '18px',
-              }}
-            >
-              {errorMessage}
-            </div>
-          )}
 
           {/* Buttons at bottom of panel */}
           <div

--- a/src/hooks/useRidershipData.ts
+++ b/src/hooks/useRidershipData.ts
@@ -52,6 +52,23 @@ export function hasCachedData(key: string): boolean {
   return !!entry && Date.now() - entry.timestamp < CACHE_TTL;
 }
 
+// Tracks fetches currently in flight (from prefetch or hooks) so callers can
+// await the existing promise instead of firing a duplicate request. This closes
+// the race where a prefetch is mid-flight when a component's hook mounts for
+// the same cache key — previously each fired its own network request.
+const inflight = new Map<string, Promise<void>>();
+
+export function getInflightFetch(cacheKey: string): Promise<void> | undefined {
+  return inflight.get(cacheKey);
+}
+
+export function registerInflightFetch(cacheKey: string, promise: Promise<void>): void {
+  inflight.set(cacheKey, promise);
+  promise.finally(() => {
+    if (inflight.get(cacheKey) === promise) inflight.delete(cacheKey);
+  });
+}
+
 // Types for hook responses
 interface UseRidershipResult<T> {
   data: T | null;
@@ -99,6 +116,24 @@ function useRidershipFetch<T>(
       return;
     }
 
+    // If a prefetch (or another hook) is already fetching this key, await it
+    // instead of firing a duplicate request.
+    const pending = getInflightFetch(cacheKey);
+    if (pending) {
+      setIsLoading(true);
+      try {
+        await pending;
+        const afterWait = getCachedData<T>(cacheKey);
+        if (afterWait) {
+          setData(afterWait);
+          return;
+        }
+        // Fall through to a fresh fetch if prefetch ultimately didn't populate.
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
     // Cancel any in-flight request
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
@@ -108,27 +143,32 @@ function useRidershipFetch<T>(
     setIsLoading(true);
     setError(null);
 
-    try {
-      const response = await fetch(url, {
-        signal: abortControllerRef.current.signal,
-      });
+    const task = (async () => {
+      try {
+        const response = await fetch(url, {
+          signal: abortControllerRef.current!.signal,
+        });
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
 
-      const result = await response.json();
-      setCachedData(cacheKey, result);
-      setData(result);
-    } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
-        // Request was cancelled, ignore
-        return;
+        const result = await response.json();
+        setCachedData(cacheKey, result);
+        setData(result);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          // Request was cancelled, ignore
+          return;
+        }
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+      } finally {
+        setIsLoading(false);
       }
-      setError(err instanceof Error ? err : new Error('Unknown error'));
-    } finally {
-      setIsLoading(false);
-    }
+    })();
+
+    registerInflightFetch(cacheKey, task);
+    await task;
   }, [endpoint, filters, enabled]);
 
   useEffect(() => {

--- a/src/lib/utils/prefetch.ts
+++ b/src/lib/utils/prefetch.ts
@@ -9,8 +9,14 @@
  */
 
 import type { WalkthroughStep } from '@/types/insights';
+import type { RoutePatternInfo } from '@/lib/data/loaders';
 import { FilterState, buildApiUrl, getCacheKey } from '@/lib/utils/filterBuilder';
-import { setCachedData, hasCachedData } from '@/hooks/useRidershipData';
+import {
+  setCachedData,
+  hasCachedData,
+  getInflightFetch,
+  registerInflightFetch,
+} from '@/hooks/useRidershipData';
 
 export interface RouteListItem {
   id: string;
@@ -22,23 +28,55 @@ interface PrefetchOptions {
   includeGrid?: boolean;
   /** Fetch comparison-mode data when the step opts in. */
   includeComparison?: boolean;
+  /**
+   * Route pattern data used to resolve `step.filters.pattern` → direction_id,
+   * so the prefetched URL matches the live query (which always appends
+   * `&direction=` when a pattern is selected). Without this, pages with a
+   * pattern filter cache-miss and re-fetch every endpoint on step change.
+   */
+  routePatterns?: { [routeId: string]: RoutePatternInfo };
 }
 
 const LS_PREFIX = 'ridership-cache:';
-const LS_ENTRY_MAX_BYTES = 4_500_000; // ~4.5 MB per entry; chrome LS quota is ~5–10 MB
+// Per-entry cap: keep small summaries (system / by-date / by-day) but skip grids
+// and other large payloads so a single insight doesn't monopolize the quota.
+const LS_ENTRY_MAX_BYTES = 250_000;
+// Total budget across all ridership-cache:* entries. Leaves plenty of the
+// ~5 MB per-origin quota for bookmarks (and whatever else writes to LS).
+const LS_TOTAL_BUDGET_BYTES = 1_500_000;
 const LS_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 
-// Dedupe in-flight prefetches so duplicate callers share one network request.
-const inflight = new Map<string, Promise<void>>();
+
+function resolveDirectionId(
+  routeIdFullOrShort: string,
+  pattern: string,
+  routesList: RouteListItem[],
+  routePatterns?: { [routeId: string]: RoutePatternInfo },
+): '0' | '1' | undefined {
+  if (!routePatterns) return undefined;
+  // routePatterns is keyed by full id; resolve from short name if needed.
+  const fullId = resolveRouteId(routeIdFullOrShort, routesList);
+  const info = routePatterns[fullId];
+  if (!info) return undefined;
+  const match = info.patterns.find(p => p.headsign === pattern);
+  if (!match) return undefined;
+  return match.direction_id === '0' || match.direction_id === '1' ? match.direction_id : undefined;
+}
 
 function buildFilterState(
   step: WalkthroughStep,
   which: 'primary' | 'comparison',
+  routesList: RouteListItem[],
+  routePatterns?: { [routeId: string]: RoutePatternInfo },
 ): FilterState | null {
   const f = step.filters;
   const startStr = which === 'primary' ? f.startDate : f.comparisonStartDate;
   const endStr = which === 'primary' ? f.endDate : f.comparisonEndDate;
   if (!startStr || !endStr) return null;
+
+  const directionId = f.pattern && f.routeId
+    ? resolveDirectionId(f.routeId, f.pattern, routesList, routePatterns)
+    : undefined;
 
   return {
     startDate: new Date(startStr + 'T00:00:00'),
@@ -47,6 +85,7 @@ function buildFilterState(
     customDays: f.customDays ?? [],
     timeMode: f.timeMode ?? 'all',
     timePeriods: f.timePeriods ?? [],
+    directionId,
   };
 }
 
@@ -55,24 +94,97 @@ function resolveRouteId(raw: string, routesList: RouteListItem[]): string {
   return match ? match.id : raw;
 }
 
-function endpointsForStep(step: WalkthroughStep, routesList: RouteListItem[], opts: PrefetchOptions): string[] {
+interface StepEndpoints {
+  /** Endpoints to fetch right away (cheap summaries, stop lists, segment geometry). */
+  immediate: string[];
+  /** Endpoints deferred to idle time (grid — large payload, server-side aggregation). */
+  deferred: string[];
+}
+
+/**
+ * A step only renders segment coloring (which is what needs the grid) when it's
+ * on the Summary tab. The Trips tab shows a list and has no use for grid data,
+ * so skip the grid fetch entirely for those steps even if the caller opted in.
+ */
+function stepNeedsGrid(step: WalkthroughStep): boolean {
+  const tab = step.filters.routeTab;
+  return !tab || tab === 'Summary' || tab === 'Grid';
+}
+
+function endpointsForStep(step: WalkthroughStep, routesList: RouteListItem[], opts: PrefetchOptions): StepEndpoints {
   const f = step.filters;
   if (f.tab === 'system') {
-    return ['system', 'system/by-date', 'system/by-day'];
+    return { immediate: ['system', 'system/by-date', 'system/by-day'], deferred: [] };
   }
   if (f.tab === 'routes' && f.routeId) {
     const id = resolveRouteId(f.routeId, routesList);
-    const base = [
+    const immediate = [
       `route/${id}`,
       `route/${id}/by-date`,
       `route/${id}/by-day`,
       `route/${id}/stops`,
       `route/${id}/segments`,
     ];
-    if (opts.includeGrid) base.push(`route/${id}/grid`);
-    return base;
+    const deferred = opts.includeGrid && stepNeedsGrid(step) ? [`route/${id}/grid`] : [];
+    return { immediate, deferred };
   }
-  return [];
+  return { immediate: [], deferred: [] };
+}
+
+// Cross-call dedup: once we've issued a prefetch for a cache key in this tab session,
+// don't issue it again even after the inflight promise resolves. Keeps repeat callers
+// (briefing mount → card click → close → click again) from re-queuing the same work.
+const prefetchedKeys = new Set<string>();
+
+function schedulePrefetch(endpoint: string, filterState: FilterState): void {
+  const cacheKey = getCacheKey(endpoint, filterState);
+  if (!cacheKey || prefetchedKeys.has(cacheKey)) return;
+  prefetchedKeys.add(cacheKey);
+  void prefetchOne(endpoint, filterState);
+}
+
+// Run deferred work off the main thread's critical path. Prefer requestIdleCallback
+// so we don't compete with the panel/map's initial paint; fall back to setTimeout.
+function runWhenIdle(cb: () => void): void {
+  if (typeof window === 'undefined') return;
+  const w = window as typeof window & { requestIdleCallback?: (fn: () => void, opts?: { timeout?: number }) => number };
+  if (typeof w.requestIdleCallback === 'function') {
+    w.requestIdleCallback(cb, { timeout: 1500 });
+  } else {
+    setTimeout(cb, 300);
+  }
+}
+
+// Collect existing ridership-cache entries with their size + timestamp.
+// Corrupt / legacy entries get their ts forced to 0 so they're evicted first.
+function listCacheEntries(): Array<{ key: string; bytes: number; ts: number }> {
+  const out: Array<{ key: string; bytes: number; ts: number }> = [];
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i);
+    if (!key || !key.startsWith(LS_PREFIX)) continue;
+    const raw = window.localStorage.getItem(key);
+    if (!raw) continue;
+    let ts = 0;
+    try {
+      const parsed = JSON.parse(raw) as { ts?: number };
+      if (typeof parsed?.ts === 'number') ts = parsed.ts;
+    } catch { /* ts stays 0 — treat as oldest */ }
+    out.push({ key, bytes: raw.length, ts });
+  }
+  return out;
+}
+
+// Evict oldest ridership-cache entries until `entries`-total + `incoming` fits
+// within the total budget. Operates on the passed array in place.
+function evictToBudget(entries: Array<{ key: string; bytes: number; ts: number }>, incoming: number): void {
+  let total = entries.reduce((sum, e) => sum + e.bytes, 0);
+  if (total + incoming <= LS_TOTAL_BUDGET_BYTES) return;
+  entries.sort((a, b) => a.ts - b.ts); // oldest first
+  while (entries.length > 0 && total + incoming > LS_TOTAL_BUDGET_BYTES) {
+    const oldest = entries.shift()!;
+    try { window.localStorage.removeItem(oldest.key); } catch { /* ignore */ }
+    total -= oldest.bytes;
+  }
 }
 
 function tryPersist(cacheKey: string, data: unknown): void {
@@ -80,7 +192,10 @@ function tryPersist(cacheKey: string, data: unknown): void {
   try {
     const payload = JSON.stringify({ data, ts: Date.now() });
     if (payload.length > LS_ENTRY_MAX_BYTES) return; // oversized (likely grid); skip
-    window.localStorage.setItem(LS_PREFIX + cacheKey, payload);
+    const storageKey = LS_PREFIX + cacheKey;
+    const entries = listCacheEntries().filter(e => e.key !== storageKey);
+    evictToBudget(entries, payload.length);
+    window.localStorage.setItem(storageKey, payload);
   } catch {
     // Quota exceeded or storage disabled — silent
   }
@@ -92,8 +207,8 @@ function prefetchOne(endpoint: string, filterState: FilterState): Promise<void> 
   if (!url || !cacheKey) return Promise.resolve();
   // Already in memory — nothing to do.
   if (hasCachedData(cacheKey)) return Promise.resolve();
-  // Already fetching — share the existing promise.
-  const existing = inflight.get(cacheKey);
+  // Already fetching (from prefetch OR a component hook) — share the promise.
+  const existing = getInflightFetch(cacheKey);
   if (existing) return existing;
   const task = (async () => {
     try {
@@ -104,36 +219,48 @@ function prefetchOne(endpoint: string, filterState: FilterState): Promise<void> 
       tryPersist(cacheKey, data);
     } catch {
       // Swallow — normal useRidershipFetch path will retry on demand
-    } finally {
-      inflight.delete(cacheKey);
     }
   })();
-  inflight.set(cacheKey, task);
+  registerInflightFetch(cacheKey, task);
   return task;
 }
 
 /**
  * Warm the in-memory ridership cache for the given walkthrough steps.
  * Fire-and-forget; non-blocking. Safe to call multiple times.
+ *
+ * Two-phase fetching: summaries / stops / segments fire immediately so the
+ * story panel and map shell paint fast; the large grid endpoint is deferred
+ * to idle time so it doesn't compete with the initial paint.
  */
 export function prefetchWalkthroughSteps(
   steps: WalkthroughStep[],
   routesList: RouteListItem[],
   opts: PrefetchOptions = {},
 ): void {
+  const deferredTasks: Array<{ ep: string; filter: FilterState }> = [];
+
   for (const step of steps) {
-    const primary = buildFilterState(step, 'primary');
-    const endpoints = endpointsForStep(step, routesList, opts);
-    if (primary && endpoints.length > 0) {
-      for (const ep of endpoints) void prefetchOne(ep, primary);
+    const primary = buildFilterState(step, 'primary', routesList, opts.routePatterns);
+    const { immediate, deferred } = endpointsForStep(step, routesList, opts);
+    if (primary) {
+      for (const ep of immediate) schedulePrefetch(ep, primary);
+      for (const ep of deferred) deferredTasks.push({ ep, filter: primary });
     }
 
     if (opts.includeComparison && step.filters.comparisonMode) {
-      const comparison = buildFilterState(step, 'comparison');
-      if (comparison && endpoints.length > 0) {
-        for (const ep of endpoints) void prefetchOne(ep, comparison);
+      const comparison = buildFilterState(step, 'comparison', routesList, opts.routePatterns);
+      if (comparison) {
+        for (const ep of immediate) schedulePrefetch(ep, comparison);
+        for (const ep of deferred) deferredTasks.push({ ep, filter: comparison });
       }
     }
+  }
+
+  if (deferredTasks.length > 0) {
+    runWhenIdle(() => {
+      for (const { ep, filter } of deferredTasks) schedulePrefetch(ep, filter);
+    });
   }
 }
 


### PR DESCRIPTION
Bundles several fixes for the Route 44 story walkthrough:

- Fix pattern filter getting wiped on same-route step changes. The route-change reset effect ran when selectedRouteId flipped from the short name to the full id (once routesList loaded), nulling selectedPattern after applyWalkthroughStep just set it.

- Fix empty map on page 1 when the user clicks a story card before routesList has loaded. Added a re-resolution effect that maps the cached short name to the full id once routesList arrives.

- Prefetch perf: defer heavy grid endpoint to idle time, skip grid for steps on the Trips tab (no segment coloring), and dedup prefetched cache keys so repeat calls are no-ops.

- Include direction_id in prefetched URLs for pattern-scoped steps so the cache key matches the live query (pages 2-4 were cache-missing and refetching ~10 endpoints each).

- Share an in-flight fetch registry between prefetch and the data hooks. Previously both maintained separate inflight maps, so a hook firing mid-prefetch would fire a duplicate network request. Hook now awaits the existing promise.

- Fix shadow band next to the story panel: loading scrim left position was hardcoded to the data panel's right edge in non-story layouts, falling inside the story panel. Now positioned correctly and transparent in story mode.

- Remove duplicate bookmark save error UI: kept the toast, removed the inline red banner in the save modal.